### PR TITLE
Remove hard-coded version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ export TERRAFORM_PROVIDER_REPO ?= https://github.com/launchdarkly/terraform-prov
 export TERRAFORM_PROVIDER_VERSION ?= 2.23.1
 export TERRAFORM_PROVIDER_DOWNLOAD_NAME ?= terraform-provider-launchdarkly
 export TERRAFORM_PROVIDER_DOWNLOAD_URL_PREFIX ?= https://github.com/launchdarkly/$(TERRAFORM_PROVIDER_DOWNLOAD_NAME)/releases/download/v$(TERRAFORM_PROVIDER_VERSION)/
-export TERRAFORM_NATIVE_PROVIDER_BINARY ?= terraform-provider-launchdarkly_2.21.5
+export TERRAFORM_NATIVE_PROVIDER_BINARY ?= terraform-provider-launchdarkly_$(TERRAFORM_PROVIDER_VERSION)
 export TERRAFORM_DOCS_PATH ?= docs/resources
 
 


### PR DESCRIPTION
Figured this should be changed to just reference `TERRAFORM_PROVIDER_VERSION`. It's not clear to me if `TERRAFORM_NATIVE_PROVIDER_BINARY` is even used because I would have expected it to fail before this change 🤷🏼 
