### PR TITLE
fix: Update project_key cross-resource reference on Environment resource

### DIFF
--- a/apis/project/v1alpha1/zz_environment_types.go
+++ b/apis/project/v1alpha1/zz_environment_types.go
@@ -173,7 +173,16 @@ type EnvironmentInitParameters struct {
 
 	// (String) The LaunchDarkly project key. A change in this field will force the destruction of the existing resource and the creation of a new one.
 	// The LaunchDarkly project key. A change in this field will force the destruction of the existing resource and the creation of a new one.
+	// +crossplane:generate:reference:type=github.com/launchdarkly/crossplane-provider-launchdarkly/apis/project/v1alpha1.Project
 	ProjectKey *string `json:"projectKey,omitempty" tf:"project_key,omitempty"`
+
+	// Reference to a Project in project to populate projectKey.
+	// +kubebuilder:validation:Optional
+	ProjectKeyRef *v1.Reference `json:"projectKeyRef,omitempty" tf:"-"`
+
+	// Selector for a Project in project to populate projectKey.
+	// +kubebuilder:validation:Optional
+	ProjectKeySelector *v1.Selector `json:"projectKeySelector,omitempty" tf:"-"`
 
 	// (Boolean) Set to true if this environment requires comments for flag and segment changes. This field will default to false when not set.
 	// Set to `true` if this environment requires comments for flag and segment changes. This field will default to `false` when not set.
@@ -286,8 +295,17 @@ type EnvironmentParameters struct {
 
 	// (String) The LaunchDarkly project key. A change in this field will force the destruction of the existing resource and the creation of a new one.
 	// The LaunchDarkly project key. A change in this field will force the destruction of the existing resource and the creation of a new one.
+	// +crossplane:generate:reference:type=github.com/launchdarkly/crossplane-provider-launchdarkly/apis/project/v1alpha1.Project
 	// +kubebuilder:validation:Optional
 	ProjectKey *string `json:"projectKey,omitempty" tf:"project_key,omitempty"`
+
+	// Reference to a Project in project to populate projectKey.
+	// +kubebuilder:validation:Optional
+	ProjectKeyRef *v1.Reference `json:"projectKeyRef,omitempty" tf:"-"`
+
+	// Selector for a Project in project to populate projectKey.
+	// +kubebuilder:validation:Optional
+	ProjectKeySelector *v1.Selector `json:"projectKeySelector,omitempty" tf:"-"`
 
 	// (Boolean) Set to true if this environment requires comments for flag and segment changes. This field will default to false when not set.
 	// Set to `true` if this environment requires comments for flag and segment changes. This field will default to `false` when not set.
@@ -345,7 +363,6 @@ type Environment struct {
 	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.color) || (has(self.initProvider) && has(self.initProvider.color))",message="spec.forProvider.color is a required parameter"
 	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.key) || (has(self.initProvider) && has(self.initProvider.key))",message="spec.forProvider.key is a required parameter"
 	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.name) || (has(self.initProvider) && has(self.initProvider.name))",message="spec.forProvider.name is a required parameter"
-	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.projectKey) || (has(self.initProvider) && has(self.initProvider.projectKey))",message="spec.forProvider.projectKey is a required parameter"
 	Spec   EnvironmentSpec   `json:"spec"`
 	Status EnvironmentStatus `json:"status,omitempty"`
 }

--- a/apis/project/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/project/v1alpha1/zz_generated.deepcopy.go
@@ -834,6 +834,16 @@ func (in *EnvironmentInitParameters) DeepCopyInto(out *EnvironmentInitParameters
 		*out = new(string)
 		**out = **in
 	}
+	if in.ProjectKeyRef != nil {
+		in, out := &in.ProjectKeyRef, &out.ProjectKeyRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ProjectKeySelector != nil {
+		in, out := &in.ProjectKeySelector, &out.ProjectKeySelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.RequireComments != nil {
 		in, out := &in.RequireComments, &out.RequireComments
 		*out = new(bool)
@@ -1036,6 +1046,16 @@ func (in *EnvironmentParameters) DeepCopyInto(out *EnvironmentParameters) {
 		in, out := &in.ProjectKey, &out.ProjectKey
 		*out = new(string)
 		**out = **in
+	}
+	if in.ProjectKeyRef != nil {
+		in, out := &in.ProjectKeyRef, &out.ProjectKeyRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ProjectKeySelector != nil {
+		in, out := &in.ProjectKeySelector, &out.ProjectKeySelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.RequireComments != nil {
 		in, out := &in.RequireComments, &out.RequireComments

--- a/config/environment/config.go
+++ b/config/environment/config.go
@@ -7,7 +7,7 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("launchdarkly_environment", func(r *config.Resource) {
 		r.ShortGroup = "project"
 		r.Kind = "Environment"
-		r.References["project"] = config.Reference{
+		r.References["project_key"] = config.Reference{
 			TerraformName: "launchdarkly_project",
 		}
 	})

--- a/examples-generated/project/v1alpha1/environment.yaml
+++ b/examples-generated/project/v1alpha1/environment.yaml
@@ -11,7 +11,9 @@ spec:
     color: ff00ff
     key: staging
     name: Staging
-    projectKey: example-project
+    projectKeySelector:
+      matchLabels:
+        testing.upbound.io/example-name: example
     tags:
     - terraform
     - staging

--- a/examples/project_environment_and_flag/project_environment.yaml
+++ b/examples/project_environment_and_flag/project_environment.yaml
@@ -36,7 +36,8 @@ spec:
   forProvider:
     key: name-dev
     name: Name Dev Environment
-    projectKey: crossplane-project
+    projectKeyRef:
+      name: crossplane-project
     color: FFFFFF
     tags:
       - managed-by-crossplane

--- a/package/crds/project.launchdarkly.com_environments.yaml
+++ b/package/crds/project.launchdarkly.com_environments.yaml
@@ -173,6 +173,80 @@ spec:
                       (String) The LaunchDarkly project key. A change in this field will force the destruction of the existing resource and the creation of a new one.
                       The LaunchDarkly project key. A change in this field will force the destruction of the existing resource and the creation of a new one.
                     type: string
+                  projectKeyRef:
+                    description: Reference to a Project in project to populate projectKey.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  projectKeySelector:
+                    description: Selector for a Project in project to populate projectKey.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   requireComments:
                     description: |-
                       (Boolean) Set to true if this environment requires comments for flag and segment changes. This field will default to false when not set.
@@ -300,6 +374,80 @@ spec:
                       (String) The LaunchDarkly project key. A change in this field will force the destruction of the existing resource and the creation of a new one.
                       The LaunchDarkly project key. A change in this field will force the destruction of the existing resource and the creation of a new one.
                     type: string
+                  projectKeyRef:
+                    description: Reference to a Project in project to populate projectKey.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  projectKeySelector:
+                    description: Selector for a Project in project to populate projectKey.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   requireComments:
                     description: |-
                       (Boolean) Set to true if this environment requires comments for flag and segment changes. This field will default to false when not set.
@@ -499,10 +647,6 @@ spec:
               rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
                 || ''Update'' in self.managementPolicies) || has(self.forProvider.name)
                 || (has(self.initProvider) && has(self.initProvider.name))'
-            - message: spec.forProvider.projectKey is a required parameter
-              rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
-                || ''Update'' in self.managementPolicies) || has(self.forProvider.projectKey)
-                || (has(self.initProvider) && has(self.initProvider.projectKey))'
           status:
             description: EnvironmentStatus defines the observed state of Environment.
             properties:


### PR DESCRIPTION
This PR fixed the Environment resources project_key cross-resource reference. This was not working because we were not referencing the attribute name used by terraform (we used `project` instead of `project_key`). 

I updated our example and ran it locally to confirm this works.
