### PR TITLE
feat: Add projectKey reference to EnvironmentSegment resource

### DIFF
--- a/apis/project/v1alpha1/zz_environmentsegment_types.go
+++ b/apis/project/v1alpha1/zz_environmentsegment_types.go
@@ -146,7 +146,16 @@ type EnvironmentSegmentInitParameters struct {
 
 	// (String) The segment's project key. A change in this field will force the destruction of the existing resource and the creation of a new one.
 	// The segment's project key. A change in this field will force the destruction of the existing resource and the creation of a new one.
+	// +crossplane:generate:reference:type=github.com/launchdarkly/crossplane-provider-launchdarkly/apis/project/v1alpha1.Project
 	ProjectKey *string `json:"projectKey,omitempty" tf:"project_key,omitempty"`
+
+	// Reference to a Project in project to populate projectKey.
+	// +kubebuilder:validation:Optional
+	ProjectKeyRef *v1.Reference `json:"projectKeyRef,omitempty" tf:"-"`
+
+	// Selector for a Project in project to populate projectKey.
+	// +kubebuilder:validation:Optional
+	ProjectKeySelector *v1.Selector `json:"projectKeySelector,omitempty" tf:"-"`
 
 	// (Block List) List of nested custom rule blocks to apply to the segment. This attribute is not valid when unbounded is set to true. (see below for nested schema)
 	// List of nested custom rule blocks to apply to the segment. This attribute is not valid when `unbounded` is set to `true`.
@@ -283,8 +292,17 @@ type EnvironmentSegmentParameters struct {
 
 	// (String) The segment's project key. A change in this field will force the destruction of the existing resource and the creation of a new one.
 	// The segment's project key. A change in this field will force the destruction of the existing resource and the creation of a new one.
+	// +crossplane:generate:reference:type=github.com/launchdarkly/crossplane-provider-launchdarkly/apis/project/v1alpha1.Project
 	// +kubebuilder:validation:Optional
 	ProjectKey *string `json:"projectKey,omitempty" tf:"project_key,omitempty"`
+
+	// Reference to a Project in project to populate projectKey.
+	// +kubebuilder:validation:Optional
+	ProjectKeyRef *v1.Reference `json:"projectKeyRef,omitempty" tf:"-"`
+
+	// Selector for a Project in project to populate projectKey.
+	// +kubebuilder:validation:Optional
+	ProjectKeySelector *v1.Selector `json:"projectKeySelector,omitempty" tf:"-"`
 
 	// (Block List) List of nested custom rule blocks to apply to the segment. This attribute is not valid when unbounded is set to true. (see below for nested schema)
 	// List of nested custom rule blocks to apply to the segment. This attribute is not valid when `unbounded` is set to `true`.
@@ -477,7 +495,6 @@ type EnvironmentSegment struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.key) || (has(self.initProvider) && has(self.initProvider.key))",message="spec.forProvider.key is a required parameter"
 	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.name) || (has(self.initProvider) && has(self.initProvider.name))",message="spec.forProvider.name is a required parameter"
-	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.projectKey) || (has(self.initProvider) && has(self.initProvider.projectKey))",message="spec.forProvider.projectKey is a required parameter"
 	Spec   EnvironmentSegmentSpec   `json:"spec"`
 	Status EnvironmentSegmentStatus `json:"status,omitempty"`
 }

--- a/apis/project/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/project/v1alpha1/zz_generated.deepcopy.go
@@ -1191,6 +1191,16 @@ func (in *EnvironmentSegmentInitParameters) DeepCopyInto(out *EnvironmentSegment
 		*out = new(string)
 		**out = **in
 	}
+	if in.ProjectKeyRef != nil {
+		in, out := &in.ProjectKeyRef, &out.ProjectKeyRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ProjectKeySelector != nil {
+		in, out := &in.ProjectKeySelector, &out.ProjectKeySelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Rules != nil {
 		in, out := &in.Rules, &out.Rules
 		*out = make([]RulesInitParameters, len(*in))
@@ -1450,6 +1460,16 @@ func (in *EnvironmentSegmentParameters) DeepCopyInto(out *EnvironmentSegmentPara
 		in, out := &in.ProjectKey, &out.ProjectKey
 		*out = new(string)
 		**out = **in
+	}
+	if in.ProjectKeyRef != nil {
+		in, out := &in.ProjectKeyRef, &out.ProjectKeyRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ProjectKeySelector != nil {
+		in, out := &in.ProjectKeySelector, &out.ProjectKeySelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Rules != nil {
 		in, out := &in.Rules, &out.Rules

--- a/apis/project/v1alpha1/zz_generated.resolvers.go
+++ b/apis/project/v1alpha1/zz_generated.resolvers.go
@@ -80,6 +80,22 @@ func (mg *EnvironmentSegment) ResolveReferences(ctx context.Context, c client.Re
 	mg.Spec.ForProvider.EnvKeyRef = rsp.ResolvedReference
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.ProjectKey),
+		Extract:      reference.ExternalName(),
+		Reference:    mg.Spec.ForProvider.ProjectKeyRef,
+		Selector:     mg.Spec.ForProvider.ProjectKeySelector,
+		To: reference.To{
+			List:    &ProjectList{},
+			Managed: &Project{},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.ForProvider.ProjectKey")
+	}
+	mg.Spec.ForProvider.ProjectKey = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.ProjectKeyRef = rsp.ResolvedReference
+
+	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.EnvKey),
 		Extract:      extractors.FieldExtractor("key"),
 		Reference:    mg.Spec.InitProvider.EnvKeyRef,
@@ -94,6 +110,22 @@ func (mg *EnvironmentSegment) ResolveReferences(ctx context.Context, c client.Re
 	}
 	mg.Spec.InitProvider.EnvKey = reference.ToPtrValue(rsp.ResolvedValue)
 	mg.Spec.InitProvider.EnvKeyRef = rsp.ResolvedReference
+
+	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.ProjectKey),
+		Extract:      reference.ExternalName(),
+		Reference:    mg.Spec.InitProvider.ProjectKeyRef,
+		Selector:     mg.Spec.InitProvider.ProjectKeySelector,
+		To: reference.To{
+			List:    &ProjectList{},
+			Managed: &Project{},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.InitProvider.ProjectKey")
+	}
+	mg.Spec.InitProvider.ProjectKey = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.InitProvider.ProjectKeyRef = rsp.ResolvedReference
 
 	return nil
 }

--- a/config/segment/config.go
+++ b/config/segment/config.go
@@ -14,5 +14,9 @@ func Configure(p *config.Provider) {
 			TerraformName: "launchdarkly_environment",
 			Extractor:     extractors.FieldExtractorFnReference("key"),
 		}
+
+		r.References["project_key"] = config.Reference{
+			TerraformName: "launchdarkly_project",
+		}
 	})
 }

--- a/examples-generated/project/v1alpha1/environmentsegment.yaml
+++ b/examples-generated/project/v1alpha1/environmentsegment.yaml
@@ -25,7 +25,9 @@ spec:
       - account2
     key: example-segment-key
     name: example segment
-    projectKey: example-project
+    projectKeySelector:
+      matchLabels:
+        testing.upbound.io/example-name: example
     rules:
     - clauses:
       - attribute: country

--- a/examples/project_environment_and_flag/segment.yaml
+++ b/examples/project_environment_and_flag/segment.yaml
@@ -1,0 +1,30 @@
+apiVersion: project.launchdarkly.com/v1alpha1
+kind: EnvironmentSegment
+metadata:
+  name: segment-with-refs
+spec:
+  forProvider:
+    projectKeyRef:
+      name: crossplane-project
+    envKeyRef:
+      name: name-dev-environment
+    key: example-segment
+    name: Example Segment
+
+    description: This segment is managed by Crossplane
+
+    includedContexts:
+      - contextKind: account
+        values:
+          - account1
+          - account2
+
+    rules:
+      - clauses:
+          - attribute: country
+            contextKind: account
+            op: startsWith
+            values:
+              - en
+              - de
+              - un

--- a/package/crds/project.launchdarkly.com_environmentsegments.yaml
+++ b/package/crds/project.launchdarkly.com_environmentsegments.yaml
@@ -229,6 +229,80 @@ spec:
                       (String) The segment's project key. A change in this field will force the destruction of the existing resource and the creation of a new one.
                       The segment's project key. A change in this field will force the destruction of the existing resource and the creation of a new one.
                     type: string
+                  projectKeyRef:
+                    description: Reference to a Project in project to populate projectKey.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  projectKeySelector:
+                    description: Selector for a Project in project to populate projectKey.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   rules:
                     description: |-
                       (Block List) List of nested custom rule blocks to apply to the segment. This attribute is not valid when unbounded is set to true. (see below for nested schema)
@@ -479,6 +553,80 @@ spec:
                       (String) The segment's project key. A change in this field will force the destruction of the existing resource and the creation of a new one.
                       The segment's project key. A change in this field will force the destruction of the existing resource and the creation of a new one.
                     type: string
+                  projectKeyRef:
+                    description: Reference to a Project in project to populate projectKey.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  projectKeySelector:
+                    description: Selector for a Project in project to populate projectKey.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   rules:
                     description: |-
                       (Block List) List of nested custom rule blocks to apply to the segment. This attribute is not valid when unbounded is set to true. (see below for nested schema)
@@ -737,10 +885,6 @@ spec:
               rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
                 || ''Update'' in self.managementPolicies) || has(self.forProvider.name)
                 || (has(self.initProvider) && has(self.initProvider.name))'
-            - message: spec.forProvider.projectKey is a required parameter
-              rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
-                || ''Update'' in self.managementPolicies) || has(self.forProvider.projectKey)
-                || (has(self.initProvider) && has(self.initProvider.projectKey))'
           status:
             description: EnvironmentSegmentStatus defines the observed state of EnvironmentSegment.
             properties:


### PR DESCRIPTION
Similar to #15, #16, and #17, this PR adds a projectKey reference to the EnvironmentSegment resource. To test this, I added a new example that uses both a `projectKeyRef` and `envKeyRef`
