### PR TITLE
chore: Check for new Terraform provider versions every 24H

### DIFF
--- a/.github/workflows/terraform-provider-bump.yml
+++ b/.github/workflows/terraform-provider-bump.yml
@@ -2,6 +2,8 @@ name: Terraform Provider Version Bump
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 15 * * *" # Run at 15:00 UTC every day
 
 env:
   GO_VERSION: "1.21"


### PR DESCRIPTION
This PR makes the change to run the "Terraform Provider Version Bump" PR every 24H. This will be a no-op if the Terraform Provider hasn't changed and it will create a PR if the provider has changed. We can still manually trigger the action if we want to get a change out more quickly.
