### PR TITLE
chore: remove release-please PR footer

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,6 @@
       "include-component-in-tag": false
     }
   },
-  "pull-request-footer": "**LaunchDarkly Employees:** you must close and reopen this PR to trigger the tests.\n\n---\nThis PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).",
   "release-search-depth": 100,
   "commit-search-depth": 100
 }


### PR DESCRIPTION
This PR removes the release please PR footer because this is also getting copied to our releases (we do not want this).
